### PR TITLE
Resolve Issues #70 - Unable to install behind company firewall.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "temp": "^0.7.0",
     "underscore-plus": "^1.0.0",
     "cheerio": "^0.18.0",
-    "inline-css": "git://github.com/cs150bf/inline-css",
+    "inline-css": "https://github.com/cs150bf/inline-css",
     "mime": "*",
     "season": ">=5.0.2"
   }


### PR DESCRIPTION
Resolve Issues [#70](https://github.com/cs150bf/ever-notedown/issues/70) - Unable to install behind company firewall.
Change git://... to https://... to overcome firewall issue for dependency installation failure.